### PR TITLE
Add base layout and role-aware navbar (CSS-27, CSS-28)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,208 @@
+{# =============================================================================
+   Author: G. Maistrelis
+   Date: 2026-03-27
+   Description: Base layout — all pages extend this. Provides the navbar,
+                flash messages, main content block, and footer.
+   ============================================================================= #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}LibreHelp{% endblock %} — LibreHelp</title>
+
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+    crossorigin="anonymous"
+  />
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+    rel="stylesheet"
+  />
+
+  {% block extra_css %}{% endblock %}
+</head>
+
+<body class="d-flex flex-column min-vh-100 bg-light">
+
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
+    <div class="container">
+
+      <a class="navbar-brand fw-bold" href="{{ url_for('auth.login') }}">
+        <i class="bi bi-headset me-1"></i>LibreHelp
+      </a>
+
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#mainNavbar"
+        aria-controls="mainNavbar"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="mainNavbar">
+
+        {% if current_user.is_authenticated %}
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+
+          {% if current_user.role == 'customer' %}
+          {# customers only see their own tickets #}
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'tickets.my_tickets' %}active{% endif %}"
+               href="#">{# TODO: url_for('tickets.my_tickets') after CSS-23 #}
+              <i class="bi bi-ticket-perforated me-1"></i>My Tickets
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'tickets.create_ticket' %}active{% endif %}"
+               href="#">{# TODO: url_for('tickets.create_ticket') after CSS-31 #}
+              <i class="bi bi-plus-circle me-1"></i>New Ticket
+            </a>
+          </li>
+
+          {% else %}
+          {# technician/manager/admin see everything #}
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'tickets.list_tickets' %}active{% endif %}"
+               href="#">{# TODO: url_for('tickets.list_tickets') after CSS-23 #}
+              <i class="bi bi-list-task me-1"></i>All Tickets
+            </a>
+          </li>
+          {% endif %}
+
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'knowledgebase.articles' %}active{% endif %}"
+               href="#">{# TODO: url_for('knowledgebase.articles') once that blueprint is built #}
+              <i class="bi bi-journal-text me-1"></i>Articles
+            </a>
+          </li>
+
+          {% if current_user.role in ['manager', 'admin'] %}
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'employees.index' %}active{% endif %}"
+               href="#">{# TODO: url_for once employees route exists #}
+              <i class="bi bi-people me-1"></i>Employees
+            </a>
+          </li>
+          {% endif %}
+
+          {% if current_user.role == 'admin' %}
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'admin.index' %}active{% endif %}"
+               href="#">{# TODO: url_for once admin blueprint exists #}
+              <i class="bi bi-shield-lock me-1"></i>Admin Panel
+            </a>
+          </li>
+          {% endif %}
+
+        </ul>
+        {% else %}
+        <ul class="navbar-nav me-auto"></ul>
+        {% endif %}
+
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+
+          {% if current_user.is_authenticated %}
+
+          <li class="nav-item me-lg-2">
+            <a class="nav-link {% if request.endpoint == 'dashboard.index' %}active{% endif %}"
+               href="#">{# TODO: url_for('dashboard.index') once built #}
+              <i class="bi bi-speedometer2 me-1"></i>Dashboard
+            </a>
+          </li>
+
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="userDropdown"
+               role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-person-circle me-1"></i>{{ current_user.username }}
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+              <li>
+                <span class="dropdown-item-text text-muted small">{{ current_user.email }}</span>
+              </li>
+              <li>
+                <span class="dropdown-item-text">
+                  <span class="badge
+                    {% if current_user.role == 'admin' %}bg-danger
+                    {% elif current_user.role == 'manager' %}bg-warning text-dark
+                    {% elif current_user.role == 'technician' %}bg-info text-dark
+                    {% else %}bg-secondary{% endif %}">
+                    {{ current_user.role | capitalize }}
+                  </span>
+                </span>
+              </li>
+              <li><hr class="dropdown-divider" /></li>
+              <li>
+                {# logout is POST-only, so it needs a form #}
+                <form method="POST" action="{{ url_for('auth.logout') }}">
+                  <button type="submit" class="dropdown-item text-danger">
+                    <i class="bi bi-box-arrow-right me-1"></i>Logout
+                  </button>
+                </form>
+              </li>
+            </ul>
+          </li>
+
+          {% else %}
+
+          <li class="nav-item">
+            <a class="nav-link {% if request.endpoint == 'auth.login' %}active{% endif %}"
+               href="{{ url_for('auth.login') }}">
+              <i class="bi bi-box-arrow-in-right me-1"></i>Login
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="btn btn-outline-light btn-sm ms-lg-2"
+               href="{{ url_for('auth.register') }}">
+              Register
+            </a>
+          </li>
+
+          {% endif %}
+        </ul>
+
+      </div>
+    </div>
+  </nav>
+
+  {# flash messages — 'error' category maps to Bootstrap 'danger' #}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  <div class="container mt-3">
+    {% for category, message in messages %}
+    <div class="alert alert-{{ 'danger' if category == 'error' else ('info' if category == 'message' else category) }} alert-dismissible fade show" role="alert">
+      {{ message }}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% endwith %}
+
+  <main class="container my-4 flex-grow-1">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="bg-dark text-secondary text-center py-3 mt-auto small">
+    &copy; 2026 LibreHelp — Open-Source Ticketing System
+    &nbsp;|&nbsp;
+    <a href="https://github.com/ndimitrokalis/Open-Source-Development-Assignment"
+       class="text-secondary" target="_blank" rel="noopener">GitHub</a>
+  </footer>
+
+  <script
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc4s9bIOgUxi8T/jzmswFBJCy/Dy78yNTyMqGv2Kqxp"
+    crossorigin="anonymous"
+  ></script>
+
+  {% block extra_js %}{% endblock %}
+
+</body>
+</html>


### PR DESCRIPTION
## What this does
Adds the shared base layout template and role-aware navbar (CSS-27, CSS-28).
All other pages will extend base.html.

## Navbar behaviour by role
- Not logged in: Login + Register only
- Customer: My Tickets, New Ticket, Articles, Dashboard, username dropdown
- Technician/Manager/Admin: All Tickets instead of customer links
- Manager/Admin: Employees added
- Admin: Admin Panel added

## How I tested
Temporarily added a minimal stub to login.html (`{% extends 'base.html' %}`) 
to get the template to render — confirmed navbar loads correctly for the 
unauthenticated state. Stub was removed before this commit.

## What's still needed to test fully
- login.html and register.html need content before auth links are testable
- tickets_bp needs to be registered before ticket nav links work
- Authenticated navbar (role-based items, dropdown, logout) can't be tested 
  until the HTML login flow exists — currently auth routes return JSON only
- Placeholder href="#" links will be updated as each blueprint is built

## Files changed
- `app/templates/base.html` — created
