### PR TITLE
Add ticket detail page and activate navbar links (CSS-23, CSS-32)

### DIFF
--- a/app/routes/tickets.py
+++ b/app/routes/tickets.py
@@ -64,6 +64,21 @@ def my_tickets():
     return render_template("tickets/list_tickets.html", tickets=tickets, view="my")
 
 
+# CSS-32 · Ticket detail page
+
+@tickets_bp.get("/tickets/<int:ticket_id>")
+@login_required
+def ticket_detail(ticket_id: int):
+    ticket, err = _get_ticket_or_404(ticket_id)
+    if err:
+        return err
+    # customers can only view their own tickets
+    if current_user.role == Role.CUSTOMER and ticket.customer_id != current_user.id:
+        abort(403)
+    comments = ticket.replies.all()
+    return render_template("tickets/ticket_detail.html", ticket=ticket, comments=comments)
+
+
 # CSS-22 · Create ticket
 
 @tickets_bp.post("/tickets")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,7 +56,7 @@
           {# customers only see their own tickets #}
           <li class="nav-item">
             <a class="nav-link {% if request.endpoint == 'tickets.my_tickets' %}active{% endif %}"
-               href="#">{# waiting for Joanna to add GET /tickets/my route #}
+               href="{{ url_for('tickets.my_tickets') }}">
               <i class="bi bi-ticket-perforated me-1"></i>My Tickets
             </a>
           </li>
@@ -71,7 +71,7 @@
           {# technician/manager/admin see everything #}
           <li class="nav-item">
             <a class="nav-link {% if request.endpoint == 'tickets.list_tickets' %}active{% endif %}"
-               href="#">{# waiting for Joanna to add GET /tickets route #}
+               href="{{ url_for('tickets.list_tickets') }}">
               <i class="bi bi-list-task me-1"></i>All Tickets
             </a>
           </li>

--- a/app/templates/tickets/list_tickets.html
+++ b/app/templates/tickets/list_tickets.html
@@ -43,8 +43,8 @@
         <td class="text-muted small">{{ ticket.id }}</td>
 
         <td>
-          {# will link to ticket detail once CSS-33 is done #}
-          <a href="#" class="text-decoration-none fw-semibold text-dark">
+          <a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}"
+             class="text-decoration-none fw-semibold text-dark">
             {{ ticket.title }}
           </a>
         </td>

--- a/app/templates/tickets/ticket_detail.html
+++ b/app/templates/tickets/ticket_detail.html
@@ -1,0 +1,192 @@
+{# =============================================================================
+   Author: G. Maistrelis
+   Date: 2026-04-17
+   Description: Ticket detail page — shows full ticket info, metadata, and
+                the comment thread. Staff see all fields; customers see their own.
+   ============================================================================= #}
+{% extends "base.html" %}
+
+{% block title %}Ticket #{{ ticket.id }}{% endblock %}
+
+{% block content %}
+
+{# back link #}
+<a href="{{ url_for('tickets.my_tickets') if current_user.role == 'customer' else url_for('tickets.list_tickets') }}"
+   class="btn btn-outline-secondary btn-sm mb-4">
+  <i class="bi bi-arrow-left me-1"></i>Back to tickets
+</a>
+
+<div class="row g-4">
+
+  {# left column — main ticket info #}
+  <div class="col-lg-8">
+    <div class="card shadow-sm mb-4">
+      <div class="card-body">
+
+        <div class="d-flex flex-wrap gap-2 mb-2">
+          <span class="badge
+            {% if ticket.status == 'Done' %}bg-success
+            {% elif ticket.status == 'In Progress' %}bg-primary
+            {% else %}bg-secondary{% endif %}">
+            {{ ticket.status }}
+          </span>
+          <span class="badge
+            {% if ticket.type == 'Critical' %}bg-danger
+            {% elif ticket.type == 'Bug' %}bg-warning text-dark
+            {% else %}bg-info text-dark{% endif %}">
+            {{ ticket.type }}
+          </span>
+          {% if ticket.priority %}
+          <span class="badge bg-danger">High Priority</span>
+          {% endif %}
+        </div>
+
+        <h3 class="fw-bold mb-3">{{ ticket.title }}</h3>
+
+        {% if ticket.description %}
+        <p class="text-muted">{{ ticket.description }}</p>
+        {% else %}
+        <p class="text-muted fst-italic">No description provided.</p>
+        {% endif %}
+
+      </div>
+    </div>
+
+    {# comments #}
+    <div class="card shadow-sm">
+      <div class="card-header bg-white fw-semibold">
+        <i class="bi bi-chat-left-text me-2"></i>Comments ({{ comments | length }})
+      </div>
+      <div class="card-body">
+
+        {% if comments %}
+        {% for comment in comments %}
+        <div class="d-flex gap-3 mb-3">
+          <div class="flex-shrink-0">
+            <span class="avatar-circle">{{ comment.author.username[0] | upper }}</span>
+          </div>
+          <div>
+            <div class="fw-semibold small">{{ comment.author.username }}
+              <span class="text-muted fw-normal ms-2">
+                {{ comment.created_at.strftime("%d %b %Y, %H:%M") if comment.created_at else "" }}
+              </span>
+            </div>
+            <p class="mb-0">{{ comment.body }}</p>
+          </div>
+        </div>
+        {% if not loop.last %}<hr class="my-2">{% endif %}
+        {% endfor %}
+        {% else %}
+        <p class="text-muted small mb-3">No comments yet.</p>
+        {% endif %}
+
+        {# add comment form #}
+        <hr>
+        <form id="comment-form" class="mt-3">
+          <div class="mb-2">
+            <textarea id="comment-body" class="form-control" rows="3"
+                      placeholder="Add a comment..." maxlength="5000"></textarea>
+          </div>
+          <button type="submit" class="btn btn-primary btn-sm">
+            <i class="bi bi-send me-1"></i>Post comment
+          </button>
+          <span id="comment-feedback" class="ms-2 small"></span>
+        </form>
+
+      </div>
+    </div>
+  </div>
+
+  {# right column — metadata #}
+  <div class="col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-header bg-white fw-semibold">
+        <i class="bi bi-info-circle me-2"></i>Details
+      </div>
+      <ul class="list-group list-group-flush small">
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Ticket #</span>
+          <span>{{ ticket.id }}</span>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Submitted by</span>
+          <span>{{ ticket.customer_name }}</span>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Assignee</span>
+          <span>{{ ticket.assignee.username if ticket.assignee else "Unassigned" }}</span>
+        </li>
+        {% if ticket.company %}
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Company</span>
+          <span>{{ ticket.company }}</span>
+        </li>
+        {% endif %}
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Created</span>
+          <span>{{ ticket.created_at.strftime("%d %b %Y") if ticket.created_at else "—" }}</span>
+        </li>
+        {% if ticket.done_by %}
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Due by</span>
+          <span>{{ ticket.done_by.strftime("%d %b %Y") }}</span>
+        </li>
+        {% endif %}
+        {% if ticket.closed_at %}
+        <li class="list-group-item d-flex justify-content-between">
+          <span class="text-muted">Closed</span>
+          <span>{{ ticket.closed_at.strftime("%d %b %Y") }}</span>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+
+</div>
+
+{% endblock %}
+
+{% block extra_css %}
+<style>
+  .avatar-circle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #6c757d;
+    color: white;
+    font-size: 0.85rem;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+</style>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  document.getElementById('comment-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const body = document.getElementById('comment-body').value.trim();
+    const feedback = document.getElementById('comment-feedback');
+    if (!body) return;
+
+    fetch('/tickets/{{ ticket.id }}/comments', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ body: body })
+    })
+    .then(r => r.json())
+    .then(data => {
+      if (data.error) {
+        feedback.textContent = data.error;
+        feedback.className = 'ms-2 small text-danger';
+      } else {
+        // reload to show the new comment
+        location.reload();
+      }
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
CSS-23 — Activate navbar links:
- My Tickets and All Tickets links now point to real routes

CSS-32 — Ticket detail page:
- GET /tickets/<id> — full ticket view with metadata sidebar
- Comments thread with timestamps and avatars
- Post comment form (submits via JSON API, reloads on success)
- Customers get 403 if they try to view another user's ticket
